### PR TITLE
Get clock configuration from yotta config

### DIFF
--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -82,7 +82,7 @@
 #include "hal_tick.h"
 
 #ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
-#define YOTTA_CFG_HARDWARE_EXTERNALCLOCK (8000000)
+#error A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
 #endif
 
 #if defined(HSE_VALUE)

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -85,9 +85,11 @@
 #define YOTTA_CFG_HARDWARE_EXTERNALCLOCK (8000000)
 #endif
 
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
-#endif /* HSE_VALUE */
+#if defined(HSE_VALUE)
+#error HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
+#endif
+
+#define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
 
 #if !defined  (HSI_VALUE)
   #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -81,8 +81,12 @@
 #include "stm32f4xx.h"
 #include "hal_tick.h"
 
-#if !defined  (HSE_VALUE) 
-  #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz */
+#ifndef YOTTA_CFG_HARDWARE_EXT_CLK
+#define YOTTA_CFG_HARDWARE_EXT_CLK (8000000)
+#endif
+
+#if !defined  (HSE_VALUE)
+  #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXT_CLK)) /*!< Default value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSI_VALUE)
@@ -563,8 +567,8 @@ void SystemClock_Config(void)
   RCC_OscInitStruct.HSEState = RCC_HSE_ON;
   RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-  RCC_OscInitStruct.PLL.PLLM = 8;
-  RCC_OscInitStruct.PLL.PLLN = 336;
+  RCC_OscInitStruct.PLL.PLLM = HSE_VALUE/1000000;
+  RCC_OscInitStruct.PLL.PLLN = (168*2);
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
   RCC_OscInitStruct.PLL.PLLQ = 7;
   HAL_RCC_OscConfig(&RCC_OscInitStruct);

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -81,12 +81,12 @@
 #include "stm32f4xx.h"
 #include "hal_tick.h"
 
-#ifndef YOTTA_CFG_HARDWARE_EXT_CLK
-#define YOTTA_CFG_HARDWARE_EXT_CLK (8000000)
+#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
+#define YOTTA_CFG_HARDWARE_EXTERNALCLOCK (8000000)
 #endif
 
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXT_CLK)) /*!< Default value of the External oscillator in Hz */
+  #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSI_VALUE)


### PR DESCRIPTION
Since the whitespace problem was too much, here's a new PR.

cc @bogdanm @0xc0170 

As with https://github.com/ARMmbed/cmsis-core-stm32f429xi/pull/5, this should fix https://github.com/ARMmbed/cmsis-core-stm32f4/pull/11