### PR TITLE
Convert errors to warnings in case HSE is still defined

### DIFF
--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -89,6 +89,9 @@
 #endif
 
 #else
+#if defined(HSE_VALUE) && (HSE_VALUE != YOTTA_CFG_HARDWARE_EXTERNALCLOCK)
+#warning HSE_VALUE ignored, using yotta_config values instead
+#endif
 #undef  HSE_VALUE
 #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
 #endif

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -81,15 +81,16 @@
 #include "stm32f4xx.h"
 #include "hal_tick.h"
 
-#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
-#error A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
-#endif
-
 #if defined(HSE_VALUE)
-#error HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
+#warning HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
 #endif
 
+#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
+#warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
+#else
+#undef  HSE_VALUE
 #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
+#endif
 
 #if !defined  (HSI_VALUE)
   #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -81,12 +81,13 @@
 #include "stm32f4xx.h"
 #include "hal_tick.h"
 
+#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
+#warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
+
 #if defined(HSE_VALUE)
 #warning HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
 #endif
 
-#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
-#warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
 #else
 #undef  HSE_VALUE
 #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */


### PR DESCRIPTION
This ensures that HSE_VALUE definitions in older targets do not cause cmsis-core to break.

cc @bogdanm @autopulated @salkinium @0xc0170 