### PR TITLE
System - HSE value comparision fix in preprocessor

### DIFF
--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -89,7 +89,7 @@
 #endif
 
 #else
-#if defined(HSE_VALUE) && (HSE_VALUE != YOTTA_CFG_HARDWARE_EXTERNALCLOCK)
+#if defined(HSE_VALUE)
 #warning HSE_VALUE ignored, using yotta_config values instead
 #endif
 #undef  HSE_VALUE


### PR DESCRIPTION
The comparision fails by default as in ST headers they define those with a cast, we do not
provide this value, and we use config.

I left there the warning.

@bremoran 