### PR TITLE
Moved HSE_VALUE config to header

### DIFF
--- a/cmsis-core-stm32f429xi/stm32f429xx.h
+++ b/cmsis-core-stm32f429xi/stm32f429xx.h
@@ -56,6 +56,25 @@
  extern "C" {
 #endif /* __cplusplus */
   
+#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
+#warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
+
+#if defined(HSE_VALUE)
+#warning HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
+#endif
+
+#else
+#if defined(HSE_VALUE)
+#warning HSE_VALUE ignored, using yotta_config values instead
+#endif
+#undef  HSE_VALUE
+#define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
+#endif
+
+#if !defined  (HSI_VALUE)
+  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+#endif /* HSI_VALUE */
+
 /** @addtogroup Configuration_section_for_CMSIS
   * @{
   */

--- a/cmsis-core-stm32f429xi/stm32f429xx.h
+++ b/cmsis-core-stm32f429xi/stm32f429xx.h
@@ -56,20 +56,9 @@
  extern "C" {
 #endif /* __cplusplus */
   
-#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
-#warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
 
-#if defined(HSE_VALUE)
-#warning HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
-#endif
-
-#else
-#if defined(HSE_VALUE)
-#warning HSE_VALUE ignored, using yotta_config values instead
-#endif
 #undef  HSE_VALUE
 #define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
-#endif
 
 #if !defined  (HSI_VALUE)
   #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -81,25 +81,6 @@
 #include "stm32f4xx.h"
 #include "hal_tick.h"
 
-#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
-#warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
-
-#if defined(HSE_VALUE)
-#warning HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
-#endif
-
-#else
-#if defined(HSE_VALUE)
-#warning HSE_VALUE ignored, using yotta_config values instead
-#endif
-#undef  HSE_VALUE
-#define HSE_VALUE    ((uint32_t)(YOTTA_CFG_HARDWARE_EXTERNALCLOCK)) /*!< Default value of the External oscillator in Hz */
-#endif
-
-#if !defined  (HSI_VALUE)
-  #define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
-#endif /* HSI_VALUE */
-
 /**
   * @}
   */

--- a/source/system_stm32f4xx.c
+++ b/source/system_stm32f4xx.c
@@ -65,6 +65,17 @@
   ******************************************************************************
   */
 
+#ifndef YOTTA_CFG_HARDWARE_EXTERNALCLOCK
+  #warning A "config":{"hardware":{"externalClock":"<FREQ>"}} entry is required in either target.json or config.json
+  #if defined(HSE_VALUE)
+    #warning HSE_VALUE is deprecated.  Define hardware::externalClock with yotta config instead.
+  #endif
+#else
+  #if defined(HSE_VALUE)
+    #warning HSE_VALUE ignored, using yotta_config values instead
+  #endif
+#endif
+
 /** @addtogroup CMSIS
   * @{
   */


### PR DESCRIPTION
This should make the yotta config externalClock work properly and address issue #11 

Change-Id: Ie0ec346079eb2681c693f4a6fe7ce9e186ed8aef